### PR TITLE
Fix ts warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.tmp/
+.DS_Store

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,10 +39,10 @@ function App() {
           Registro de Dores
         </Typography>
         <Grid container spacing={3} justifyContent="center" alignItems="flex-start">
-          <Grid item xs={12} md={5}>
+          <Grid xs={12} md={5}>
             <PainForm onSubmit={handleNewEntry} />
           </Grid>
-          <Grid item xs={12} md={7}>
+          <Grid xs={12} md={7}>
             <PainList entries={painData} onDelete={handleDelete} />
           </Grid>
         </Grid>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Container, CssBaseline, ThemeProvider, createTheme, Typography, Snackbar, Alert } from '@mui/material'
-import Grid from '@mui/material/Unstable_Grid2'
+import Grid from '@mui/material/Grid'
 import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Container, CssBaseline, ThemeProvider, createTheme, Typography, Snackbar, Alert } from '@mui/material'
-import Grid from '@mui/material/Grid'
+import Grid from '@mui/material/Unstable_Grid2'
 import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'

--- a/src/components/PainChart.tsx
+++ b/src/components/PainChart.tsx
@@ -1,5 +1,6 @@
-import { FC, useEffect, useRef, useState } from 'react';
-import { Box, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import type { FC } from 'react';
+import { Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
 import {
     Chart as ChartJS,
     CategoryScale,
@@ -11,7 +12,6 @@ import {
     Legend
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { Chart } from 'chart.js';
 import type { PainData } from '../types/pain';
 import { format } from 'date-fns';
 
@@ -114,10 +114,8 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
             tooltip: {
                 callbacks: {
                     afterLabel: (context: any) => {
-                        const dataIndex = context.dataIndex;
-                        const datasetIndex = context.datasetIndex;
-                        const entry = data.find(e => 
-                            e.location === context.dataset.label && 
+                        const entry = data.find(e =>
+                            e.location === context.dataset.label &&
                             format(e.timestamp, 'dd/MM HH:mm') === context.label
                         );
                         return entry?.comment ? `Comentário: ${entry.comment}` : '';

--- a/src/components/PainForm.tsx
+++ b/src/components/PainForm.tsx
@@ -1,4 +1,5 @@
-import { FC, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import type { FC } from 'react';
 import { Box, Button, TextField, Slider, Typography, Paper, MenuItem, Select, InputLabel, FormControl } from '@mui/material';
 import type { PainEntry } from '../types/pain';
 import { generateId, saveEntry, getEntries } from '../services/painStorage';

--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { List, ListItem, ListItemText, IconButton, Typography, Box, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination } from '@mui/material';
+import { List, ListItem, ListItemText, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { PainEntry } from '../types/pain';
 import { format } from 'date-fns';


### PR DESCRIPTION
## Summary
- use type-only imports for React FCs
- clean unused imports
- ignore node_modules

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685be2117ee4832daa8f7c7a63085e14