### PR TITLE
Fix grid import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Container, CssBaseline, ThemeProvider, createTheme, Typography, Snackbar, Alert } from '@mui/material'
-import Grid from '@mui/material/Grid'
+import Grid from '@mui/material/GridLegacy'
 import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'


### PR DESCRIPTION
## Summary
- import the legacy Grid component from MUI

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c3ad14844832d8d9f3f4e3911afbf