### PR TITLE
Add data import/export feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Grid from '@mui/material/GridLegacy'
 import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'
+import { DataTransferButtons } from './components/DataTransferButtons'
 import { getEntries, removeEntry } from './services/painStorage'
 import type { PainData } from './types/pain'
 
@@ -47,6 +48,7 @@ function App() {
           </Grid>
         </Grid>
         <PainChart data={painData} />
+        <DataTransferButtons onChange={() => setPainData(getEntries())} />
         <Snackbar open={openSnackbar} autoHideDuration={2000} onClose={() => setOpenSnackbar(false)} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
           <Alert onClose={() => setOpenSnackbar(false)} severity="success" sx={{ width: '100%' }}>
             Registro salvo com sucesso!

--- a/src/components/DataTransferButtons.tsx
+++ b/src/components/DataTransferButtons.tsx
@@ -1,0 +1,60 @@
+import { FC, useRef } from 'react';
+import { Button, Stack } from '@mui/material';
+import { exportEntries, importEntries } from '../services/painStorage';
+
+interface DataTransferButtonsProps {
+    onChange: () => void;
+}
+
+export const DataTransferButtons: FC<DataTransferButtonsProps> = ({ onChange }) => {
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+    const handleExport = () => {
+        const dataStr = exportEntries();
+        const blob = new Blob([dataStr], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'pain-data.json';
+        link.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleImportChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            if (typeof reader.result === 'string') {
+                try {
+                    importEntries(reader.result);
+                    onChange();
+                } catch (err) {
+                    console.error('Erro ao importar dados', err);
+                }
+            }
+        };
+        reader.readAsText(file);
+        e.target.value = '';
+    };
+
+    return (
+        <>
+            <Stack direction="row" spacing={2} justifyContent="center" sx={{ mt: 3 }}>
+                <Button variant="outlined" onClick={handleExport}>
+                    Exportar Dados
+                </Button>
+                <Button variant="outlined" onClick={() => fileInputRef.current?.click()}>
+                    Importar Dados
+                </Button>
+            </Stack>
+            <input
+                type="file"
+                accept="application/json"
+                ref={fileInputRef}
+                style={{ display: 'none' }}
+                onChange={handleImportChange}
+            />
+        </>
+    );
+};

--- a/src/components/DataTransferButtons.tsx
+++ b/src/components/DataTransferButtons.tsx
@@ -1,4 +1,5 @@
-import { FC, useRef } from 'react';
+import { useRef } from 'react';
+import type { FC, ChangeEvent } from 'react';
 import { Button, Stack } from '@mui/material';
 import { exportEntries, importEntries } from '../services/painStorage';
 
@@ -20,7 +21,7 @@ export const DataTransferButtons: FC<DataTransferButtonsProps> = ({ onChange }) 
         URL.revokeObjectURL(url);
     };
 
-    const handleImportChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleImportChange = (e: ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (!file) return;
         const reader = new FileReader();

--- a/src/services/painStorage.ts
+++ b/src/services/painStorage.ts
@@ -46,3 +46,17 @@ export const removeEntry = (id: string): void => {
     const data = getEntries().filter(entry => entry.id !== id);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 };
+
+export const exportEntries = (): string => {
+    migratePainEntries();
+    return JSON.stringify(getEntries(), null, 2);
+};
+
+export const importEntries = (json: string): void => {
+    const parsed = JSON.parse(json) as Array<Record<string, unknown>>;
+    const entries: PainEntry[] = parsed.map(entry => ({
+        ...(entry as unknown as PainEntry),
+        timestamp: new Date(entry.timestamp as string | number)
+    }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+};


### PR DESCRIPTION
## Summary
- add `exportEntries` and `importEntries` in pain storage service
- create `DataTransferButtons` component for export/import controls
- render data transfer controls in main app

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4fa8e5a8832db53a30d95c987d30