### PR TITLE
Add intensity slider editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react'
 import { Container, CssBaseline, ThemeProvider, createTheme, Typography, Snackbar, Alert } from '@mui/material'
-import Grid from '@mui/material/Unstable_Grid2'
+import Grid from '@mui/material/GridLegacy'
 import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'
-import { getEntries, removeEntry } from './services/painStorage'
+import { getEntries, removeEntry, updateEntry } from './services/painStorage'
 import type { PainData } from './types/pain'
 
 const theme = createTheme({
@@ -31,6 +31,11 @@ function App() {
     setPainData(getEntries())
   }
 
+  const handleUpdateIntensity = (id: string, value: number) => {
+    updateEntry(id, { intensity: value })
+    setPainData(getEntries())
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -43,7 +48,7 @@ function App() {
             <PainForm onSubmit={handleNewEntry} />
           </Grid>
           <Grid xs={12} md={7}>
-            <PainList entries={painData} onDelete={handleDelete} />
+            <PainList entries={painData} onDelete={handleDelete} onIntensityChange={handleUpdateIntensity} />
           </Grid>
         </Grid>
         <PainChart data={painData} />

--- a/src/components/PainChart.tsx
+++ b/src/components/PainChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
 import { Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
 import {
@@ -12,7 +12,8 @@ import {
     Legend
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import type { PainData } from '../types/pain';
+import type { ChartData, Chart, TooltipItem } from 'chart.js';
+import type { PainData, PainEntry } from '../types/pain';
 import { format } from 'date-fns';
 
 ChartJS.register(
@@ -30,9 +31,9 @@ interface PainChartProps {
 }
 
 export const PainChart: FC<PainChartProps> = ({ data }) => {
-    const [chartData, setChartData] = useState<any>(null);
-    const [selected, setSelected] = useState<any>(null);
-    const chartRef = useRef<any>(null);
+    const [chartData, setChartData] = useState<ChartData<'line'> | null>(null);
+    const [selected, setSelected] = useState<PainEntry | null>(null);
+    const chartRef = useRef<Chart<'line'> | undefined>(undefined);
     const pointIdsRef = useRef<string[][]>([]); // ids dos pontos por dataset
 
     useEffect(() => {
@@ -63,9 +64,9 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
 
     useEffect(() => {
         if (!chartRef.current?.canvas) return;
-        const canvas = chartRef.current.canvas || chartRef.current?.canvas;
+        const canvas = chartRef.current.canvas;
         const handleMouseMove = (event: MouseEvent) => {
-            const chart = chartRef.current?.chart || chartRef.current;
+            const chart = chartRef.current;
             if (!chart) return;
             const points = chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, true);
             if (points.length) {
@@ -86,8 +87,8 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
         };
     }, [chartData, data]);
 
-    const handlePointClick = (event: any) => {
-        const chart = chartRef.current?.chart || chartRef.current;
+    const handlePointClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+        const chart = chartRef.current;
         if (!chart || !event || !event.nativeEvent) return;
         const points = chart.getElementsAtEventForMode(event.nativeEvent, 'nearest', { intersect: true }, true);
         if (points.length) {
@@ -113,7 +114,7 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
             },
             tooltip: {
                 callbacks: {
-                    afterLabel: (context: any) => {
+                    afterLabel: (context: TooltipItem<'line'>) => {
                         const entry = data.find(e =>
                             e.location === context.dataset.label &&
                             format(e.timestamp, 'dd/MM HH:mm') === context.label

--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { List, ListItem, ListItemText, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination } from '@mui/material';
+import { List, ListItem, ListItemText, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination, Slider } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { PainEntry } from '../types/pain';
 import { format } from 'date-fns';
@@ -8,9 +8,10 @@ import { useState } from 'react';
 interface PainListProps {
   entries: PainEntry[];
   onDelete: (id: string) => void;
+  onIntensityChange?: (id: string, value: number) => void;
 }
 
-export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
+export const PainList: FC<PainListProps> = ({ entries, onDelete, onIntensityChange }) => {
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [selected, setSelected] = useState<PainEntry | null>(null);
   const [page, setPage] = useState(1);
@@ -28,20 +29,35 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
       <Typography variant="h6" gutterBottom align="center" fontWeight={600}>Todas as Dores Registradas</Typography>
       <List>
         {paginatedEntries.map(entry => (
-          <ListItem
-            key={entry.id}
-            secondaryAction={
+          <ListItem key={entry.id} sx={{ flexDirection: 'column', alignItems: 'stretch' }}>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              <ListItemButton onClick={() => setSelected(entry)} sx={{ flexGrow: 1, pr: 2 }}>
+                <ListItemText
+                  primary={`[${format(entry.timestamp, 'dd/MM HH:mm')}] ${entry.location}`}
+                  secondary={entry.comment ? 'Clique para ver comentário' : undefined}
+                />
+              </ListItemButton>
               <IconButton edge="end" aria-label="delete" onClick={e => { e.stopPropagation(); setConfirmId(entry.id); }}>
                 <DeleteIcon />
               </IconButton>
-            }
-          >
-            <ListItemButton onClick={() => setSelected(entry)}>
-              <ListItemText
-                primary={`[${format(entry.timestamp, 'dd/MM HH:mm')}] ${entry.location} - Intensidade: ${entry.intensity}`}
-                secondary={entry.comment ? 'Clique para ver comentário' : undefined}
-              />
-            </ListItemButton>
+            </div>
+            <Slider
+              value={entry.intensity}
+              onChange={(_, value) => {
+                if (onIntensityChange) {
+                  onIntensityChange(entry.id, value as number);
+                }
+                if (selected?.id === entry.id) {
+                  setSelected({ ...entry, intensity: value as number });
+                }
+              }}
+              min={1}
+              max={10}
+              step={1}
+              marks
+              valueLabelDisplay="auto"
+              sx={{ mt: 1 }}
+            />
           </ListItem>
         ))}
       </List>

--- a/src/services/painStorage.ts
+++ b/src/services/painStorage.ts
@@ -6,9 +6,9 @@ const STORAGE_KEY = 'pain_tracker_data';
 export const migratePainEntries = (): void => {
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) return;
-    const parsed = JSON.parse(data);
+    const parsed: PainEntry[] = JSON.parse(data);
     let changed = false;
-    const migrated = parsed.map((entry: any) => {
+    const migrated = parsed.map((entry) => {
         if (typeof entry.timestamp === 'string' || typeof entry.timestamp === 'number') {
             changed = true;
             return { ...entry, timestamp: new Date(entry.timestamp) };
@@ -31,7 +31,7 @@ export const getEntries = (): PainEntry[] => {
     migratePainEntries();
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) return [];
-    return JSON.parse(data).map((entry: any) => ({
+    return (JSON.parse(data) as PainEntry[]).map((entry) => ({
         ...entry,
         timestamp: new Date(entry.timestamp)
     }));
@@ -44,5 +44,14 @@ export const generateId = (): string => {
 export const removeEntry = (id: string): void => {
     migratePainEntries();
     const data = getEntries().filter(entry => entry.id !== id);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+};
+
+export const updateEntry = (id: string, updates: Partial<PainEntry>): void => {
+    migratePainEntries();
+    const data = getEntries();
+    const index = data.findIndex(entry => entry.id === id);
+    if (index === -1) return;
+    data[index] = { ...data[index], ...updates };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 };


### PR DESCRIPTION
## Summary
- allow updating a pain's intensity
- show a slider for each entry in the pain list
- update local storage utilities
- fix types in chart component

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c9e8e1a64832d8760ec9275820259