### PR TITLE
Add sliders for adjusting pain intensity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,8 @@ import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'
 import { DataTransferButtons } from './components/DataTransferButtons'
-import { getEntries, removeEntry } from './services/painStorage'
-import type { PainData } from './types/pain'
+import { getEntries, removeEntry, updateEntry } from './services/painStorage'
+import type { PainData, PainEntry } from './types/pain'
 
 const theme = createTheme({
   palette: {
@@ -32,6 +32,11 @@ function App() {
     setPainData(getEntries())
   }
 
+  const handleUpdate = (entry: PainEntry) => {
+    updateEntry(entry)
+    setPainData(getEntries())
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -44,7 +49,7 @@ function App() {
             <PainForm onSubmit={handleNewEntry} />
           </Grid>
           <Grid item xs={12} md={7}>
-            <PainList entries={painData} onDelete={handleDelete} />
+            <PainList entries={painData} onDelete={handleDelete} onUpdate={handleUpdate} />
           </Grid>
         </Grid>
         <PainChart data={painData} />

--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { List, ListItem, ListItemText, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination } from '@mui/material';
+import { List, ListItem, ListItemText, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination, Slider, Box } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { PainEntry } from '../types/pain';
 import { format } from 'date-fns';
@@ -8,9 +8,10 @@ import { useState } from 'react';
 interface PainListProps {
   entries: PainEntry[];
   onDelete: (id: string) => void;
+  onUpdate: (entry: PainEntry) => void;
 }
 
-export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
+export const PainList: FC<PainListProps> = ({ entries, onDelete, onUpdate }) => {
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [selected, setSelected] = useState<PainEntry | null>(null);
   const [page, setPage] = useState(1);
@@ -31,14 +32,28 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
           <ListItem
             key={entry.id}
             secondaryAction={
-              <IconButton edge="end" aria-label="delete" onClick={e => { e.stopPropagation(); setConfirmId(entry.id); }}>
-                <DeleteIcon />
-              </IconButton>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Slider
+                  value={entry.intensity}
+                  min={1}
+                  max={10}
+                  step={1}
+                  marks
+                  size="small"
+                  valueLabelDisplay="auto"
+                  sx={{ width: 110 }}
+                  onChange={(_, value) => onUpdate({ ...entry, intensity: value as number })}
+                  onClick={e => e.stopPropagation()}
+                />
+                <IconButton edge="end" aria-label="delete" onClick={e => { e.stopPropagation(); setConfirmId(entry.id); }}>
+                  <DeleteIcon />
+                </IconButton>
+              </Box>
             }
           >
             <ListItemButton onClick={() => setSelected(entry)}>
               <ListItemText
-                primary={`[${format(entry.timestamp, 'dd/MM HH:mm')}] ${entry.location} - Intensidade: ${entry.intensity}`}
+                primary={`[${format(entry.timestamp, 'dd/MM HH:mm')}] ${entry.location}`}
                 secondary={entry.comment ? 'Clique para ver comentário' : undefined}
               />
             </ListItemButton>

--- a/src/services/painStorage.ts
+++ b/src/services/painStorage.ts
@@ -47,6 +47,14 @@ export const removeEntry = (id: string): void => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 };
 
+export const updateEntry = (updated: PainEntry): void => {
+    migratePainEntries();
+    const data = getEntries().map(entry =>
+        entry.id === updated.id ? { ...updated } : entry
+    );
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+};
+
 export const exportEntries = (): string => {
     migratePainEntries();
     return JSON.stringify(getEntries(), null, 2);


### PR DESCRIPTION
## Summary
- implement `updateEntry` service to change existing records
- add slider widgets to each pain record for quick edits
- refresh data when slider changes via new handler in `App`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ca22e0b38832dbbe0c8608c3b6077