### PR TITLE
Fix timestamp display issues

### DIFF
--- a/src/components/PainChart.tsx
+++ b/src/components/PainChart.tsx
@@ -39,8 +39,8 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
     const pointIdsRef = useRef<(string | null)[][]>([]); // ids dos pontos por dataset
 
     useEffect(() => {
-        const sortedData = [...data].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-        const labels = sortedData.map(entry => format(entry.timestamp, 'dd/MM HH:mm'));
+        const sortedData = [...data].sort((a, b) => a.timestamp - b.timestamp);
+        const labels = sortedData.map(entry => format(new Date(entry.timestamp), 'dd/MM HH:mm'));
         const locations = Array.from(new Set(data.map(entry => entry.location)));
         const colors = locations.map((_, i) => `hsl(${(i * 360) / locations.length}, 70%, 50%)`);
         const pointIds: (string | null)[][] = [];
@@ -140,7 +140,7 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
                     afterLabel: (context: TooltipItem<'line'>) => {
                         const entry = data.find(e =>
                             e.location === context.dataset.label &&
-                            format(e.timestamp, 'dd/MM HH:mm') === context.label
+                            format(new Date(e.timestamp), 'dd/MM HH:mm') === context.label
                         );
                         return entry?.comment ? `Comentário: ${entry.comment}` : '';
                     }

--- a/src/components/PainForm.tsx
+++ b/src/components/PainForm.tsx
@@ -24,7 +24,7 @@ export const PainForm: FC<PainFormProps> = ({ onSubmit }) => {
         e.preventDefault();
         const entry: PainEntry = {
             id: generateId(),
-            timestamp: new Date(),
+            timestamp: Date.now(),
             location,
             intensity,
             comment: comment || undefined

--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -38,7 +38,7 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
           >
             <ListItemButton onClick={() => setSelected(entry)}>
               <ListItemText
-                primary={`[${format(entry.timestamp, 'dd/MM HH:mm')}] ${entry.location} - Intensidade: ${entry.intensity}`}
+                primary={`[${format(new Date(entry.timestamp), 'dd/MM HH:mm')}] ${entry.location} - Intensidade: ${entry.intensity}`}
                 secondary={entry.comment ? 'Clique para ver comentário' : undefined}
               />
             </ListItemButton>
@@ -68,7 +68,7 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
         <DialogContent sx={{ minHeight: 120 }}>
           {selected && (
             <>
-              <Typography><b>Data:</b> {format(selected.timestamp, 'dd/MM/yyyy HH:mm')}</Typography>
+              <Typography><b>Data:</b> {format(new Date(selected.timestamp), 'dd/MM/yyyy HH:mm')}</Typography>
               <Typography><b>Local:</b> {selected.location}</Typography>
               <Typography><b>Intensidade:</b> {selected.intensity}</Typography>
               <Typography sx={{ mt: 2 }}><b>Comentário:</b> {selected.comment || 'Nenhum'}</Typography>

--- a/src/services/painStorage.ts
+++ b/src/services/painStorage.ts
@@ -2,15 +2,18 @@ import type { PainEntry } from '../types/pain';
 
 const STORAGE_KEY = 'pain_tracker_data';
 
-// Função de migração para garantir que todos os timestamps sejam Date
+// Função de migração para garantir que todos os timestamps sejam números
 export const migratePainEntries = (): void => {
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) return;
     const parsed = JSON.parse(data) as Array<Record<string, unknown>>;
     let changed = false;
     const migrated = parsed.map((entry) => {
-        const timestamp = entry.timestamp instanceof Date ? entry.timestamp : new Date(entry.timestamp as string | number);
-        if (!(entry.timestamp instanceof Date)) {
+        let timestamp: number;
+        if (typeof entry.timestamp === 'number') {
+            timestamp = entry.timestamp;
+        } else {
+            timestamp = new Date(entry.timestamp as string | number).getTime();
             changed = true;
         }
         return { ...(entry as unknown as PainEntry), timestamp } as PainEntry;
@@ -33,7 +36,9 @@ export const getEntries = (): PainEntry[] => {
     if (!data) return [];
     return (JSON.parse(data) as Array<Record<string, unknown>>).map((entry) => ({
         ...(entry as unknown as PainEntry),
-        timestamp: new Date(entry.timestamp as string | number)
+        timestamp: typeof entry.timestamp === 'number'
+            ? entry.timestamp
+            : new Date(entry.timestamp as string | number).getTime()
     }));
 };
 
@@ -56,7 +61,9 @@ export const importEntries = (json: string): void => {
     const parsed = JSON.parse(json) as Array<Record<string, unknown>>;
     const entries: PainEntry[] = parsed.map(entry => ({
         ...(entry as unknown as PainEntry),
-        timestamp: new Date(entry.timestamp as string | number)
+        timestamp: typeof entry.timestamp === 'number'
+            ? entry.timestamp
+            : new Date(entry.timestamp as string | number).getTime()
     }));
     localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
 };

--- a/src/types/pain.ts
+++ b/src/types/pain.ts
@@ -1,6 +1,7 @@
 export interface PainEntry {
     id: string;
-    timestamp: Date;
+    /** Unix timestamp in milliseconds */
+    timestamp: number;
     intensity: number;
     location: string;
     comment?: string;


### PR DESCRIPTION
## Summary
- store timestamps as Unix ms numbers and convert on load
- format timestamps by converting to `Date` when rendering

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ca3daf9b4832dad5f721ad904d7a1