### PR TITLE
Add deletion button in pain details

### DIFF
--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -77,6 +77,17 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSelected(null)}>Fechar</Button>
+          {selected && (
+            <Button
+              color="error"
+              onClick={() => {
+                onDelete(selected.id)
+                setSelected(null)
+              }}
+            >
+              Excluir
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
     </Paper>


### PR DESCRIPTION
## Summary
- allow deleting a pain entry from the details dialog

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ca8867ad4832da8d0fa05cfe0d9a0