### PR TITLE
Implement delete button for pain detail view

### DIFF
--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -77,6 +77,17 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSelected(null)}>Fechar</Button>
+          <Button
+            color="error"
+            onClick={() => {
+              if (selected) {
+                onDelete(selected.id);
+                setSelected(null);
+              }
+            }}
+          >
+            Excluir
+          </Button>
         </DialogActions>
       </Dialog>
     </Paper>


### PR DESCRIPTION
## Summary
- add a delete button inside the pain detail dialog so entries can be removed directly from that view

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ca8867ad4832da8d0fa05cfe0d9a0