### PR TITLE
Add deletion of entire pain by location

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'
 import { DataTransferButtons } from './components/DataTransferButtons'
-import { getEntries, removeEntry } from './services/painStorage'
+import { getEntries, removeEntry, removeEntriesByLocation } from './services/painStorage'
 import type { PainData } from './types/pain'
 
 const theme = createTheme({
@@ -32,6 +32,11 @@ function App() {
     setPainData(getEntries())
   }
 
+  const handleDeleteLocation = (location: string) => {
+    removeEntriesByLocation(location)
+    setPainData(getEntries())
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -44,7 +49,7 @@ function App() {
             <PainForm onSubmit={handleNewEntry} />
           </Grid>
           <Grid item xs={12} md={7}>
-            <PainList entries={painData} onDelete={handleDelete} />
+            <PainList entries={painData} onDelete={handleDelete} onDeleteLocation={handleDeleteLocation} />
           </Grid>
         </Grid>
         <PainChart data={painData} />

--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -8,11 +8,13 @@ import { useState } from 'react';
 interface PainListProps {
   entries: PainEntry[];
   onDelete: (id: string) => void;
+  onDeleteLocation: (location: string) => void;
 }
 
-export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
+export const PainList: FC<PainListProps> = ({ entries, onDelete, onDeleteLocation }) => {
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [selected, setSelected] = useState<PainEntry | null>(null);
+  const [confirmLocation, setConfirmLocation] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   // Mostra todas as dores, mais recentes primeiro
   const shownEntries = entries.slice().reverse();
@@ -63,6 +65,16 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
           <Button color="error" onClick={() => { if (confirmId) { onDelete(confirmId); setConfirmId(null); } }}>Excluir</Button>
         </DialogActions>
       </Dialog>
+      <Dialog open={!!confirmLocation} onClose={() => setConfirmLocation(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Confirmar exclusão</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Excluir todos os registros desta dor?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmLocation(null)}>Cancelar</Button>
+          <Button color="error" onClick={() => { if (confirmLocation) { onDeleteLocation(confirmLocation); setConfirmLocation(null); setSelected(null); } }}>Excluir</Button>
+        </DialogActions>
+      </Dialog>
       <Dialog open={!!selected} onClose={() => setSelected(null)} maxWidth="sm" fullWidth>
         <DialogTitle>Detalhes do Registro</DialogTitle>
         <DialogContent sx={{ minHeight: 120 }}>
@@ -77,6 +89,25 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSelected(null)}>Fechar</Button>
+          {selected && (
+            <Button
+              color="error"
+              onClick={() => {
+                onDelete(selected.id)
+                setSelected(null)
+              }}
+            >
+              Excluir
+            </Button>
+          )}
+          {selected && (
+            <Button
+              color="error"
+              onClick={() => setConfirmLocation(selected.location)}
+            >
+              Excluir Dor
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
     </Paper>

--- a/src/services/painStorage.ts
+++ b/src/services/painStorage.ts
@@ -47,6 +47,12 @@ export const removeEntry = (id: string): void => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 };
 
+export const removeEntriesByLocation = (location: string): void => {
+    migratePainEntries();
+    const data = getEntries().filter(entry => entry.location !== location);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+};
+
 export const exportEntries = (): string => {
     migratePainEntries();
     return JSON.stringify(getEntries(), null, 2);


### PR DESCRIPTION
## Summary
- extend pain storage with `removeEntriesByLocation`
- add controls in `PainList` to delete all entries for the same pain
- wire new handler in `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ca8867ad4832da8d0fa05cfe0d9a0