### PR TITLE
Enable deletion of entire pain location

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { PainForm } from './components/PainForm'
 import { PainChart } from './components/PainChart'
 import { PainList } from './components/PainList'
 import { DataTransferButtons } from './components/DataTransferButtons'
-import { getEntries, removeEntry } from './services/painStorage'
+import { getEntries, removeEntry, removeEntriesByLocation } from './services/painStorage'
 import type { PainData } from './types/pain'
 
 const theme = createTheme({
@@ -32,6 +32,11 @@ function App() {
     setPainData(getEntries())
   }
 
+  const handleDeleteLocation = (location: string) => {
+    removeEntriesByLocation(location)
+    setPainData(getEntries())
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -44,7 +49,7 @@ function App() {
             <PainForm onSubmit={handleNewEntry} />
           </Grid>
           <Grid item xs={12} md={7}>
-            <PainList entries={painData} onDelete={handleDelete} />
+            <PainList entries={painData} onDelete={handleDelete} onDeleteLocation={handleDeleteLocation} />
           </Grid>
         </Grid>
         <PainChart data={painData} />

--- a/src/components/PainList.tsx
+++ b/src/components/PainList.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { List, ListItem, ListItemText, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, ListItemButton, Pagination } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import type { PainEntry } from '../types/pain';
 import { format } from 'date-fns';
 import { useState } from 'react';
@@ -8,11 +9,13 @@ import { useState } from 'react';
 interface PainListProps {
   entries: PainEntry[];
   onDelete: (id: string) => void;
+  onDeleteLocation: (location: string) => void;
 }
 
-export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
+export const PainList: FC<PainListProps> = ({ entries, onDelete, onDeleteLocation }) => {
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [selected, setSelected] = useState<PainEntry | null>(null);
+  const [confirmLocation, setConfirmLocation] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   // Mostra todas as dores, mais recentes primeiro
   const shownEntries = entries.slice().reverse();
@@ -31,9 +34,29 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
           <ListItem
             key={entry.id}
             secondaryAction={
-              <IconButton edge="end" aria-label="delete" onClick={e => { e.stopPropagation(); setConfirmId(entry.id); }}>
-                <DeleteIcon />
-              </IconButton>
+              <>
+                <IconButton
+                  edge="end"
+                  aria-label="delete-location"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setConfirmLocation(entry.location);
+                  }}
+                  sx={{ mr: 1 }}
+                >
+                  <DeleteSweepIcon />
+                </IconButton>
+                <IconButton
+                  edge="end"
+                  aria-label="delete"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setConfirmId(entry.id);
+                  }}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </>
             }
           >
             <ListItemButton onClick={() => setSelected(entry)}>
@@ -63,6 +86,16 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
           <Button color="error" onClick={() => { if (confirmId) { onDelete(confirmId); setConfirmId(null); } }}>Excluir</Button>
         </DialogActions>
       </Dialog>
+      <Dialog open={!!confirmLocation} onClose={() => setConfirmLocation(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Confirmar exclusão</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Excluir todos os registros desta dor?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmLocation(null)}>Cancelar</Button>
+          <Button color="error" onClick={() => { if (confirmLocation) { onDeleteLocation(confirmLocation); setConfirmLocation(null); setSelected(null); } }}>Excluir</Button>
+        </DialogActions>
+      </Dialog>
       <Dialog open={!!selected} onClose={() => setSelected(null)} maxWidth="sm" fullWidth>
         <DialogTitle>Detalhes do Registro</DialogTitle>
         <DialogContent sx={{ minHeight: 120 }}>
@@ -77,6 +110,25 @@ export const PainList: FC<PainListProps> = ({ entries, onDelete }) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSelected(null)}>Fechar</Button>
+          {selected && (
+            <Button
+              color="error"
+              onClick={() => {
+                onDelete(selected.id)
+                setSelected(null)
+              }}
+            >
+              Excluir
+            </Button>
+          )}
+          {selected && (
+            <Button
+              color="error"
+              onClick={() => setConfirmLocation(selected.location)}
+            >
+              Excluir Dor
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
     </Paper>

--- a/src/services/painStorage.ts
+++ b/src/services/painStorage.ts
@@ -47,6 +47,12 @@ export const removeEntry = (id: string): void => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 };
 
+export const removeEntriesByLocation = (location: string): void => {
+    migratePainEntries();
+    const data = getEntries().filter(entry => entry.location !== location);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+};
+
 export const exportEntries = (): string => {
     migratePainEntries();
     return JSON.stringify(getEntries(), null, 2);


### PR DESCRIPTION
## Summary
- extend `PainList` with a new button to remove every record for the selected pain location
- confirmation dialog uses `onDeleteLocation` handler from `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ca8867ad4832da8d0fa05cfe0d9a0