### PR TITLE
Improve chart usability on small screens

### DIFF
--- a/src/components/PainChart.tsx
+++ b/src/components/PainChart.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
-import { Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import { Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography, IconButton } from '@mui/material';
+import ZoomOutMapIcon from '@mui/icons-material/ZoomOutMap';
+import CloseIcon from '@mui/icons-material/Close';
 import {
     Chart as ChartJS,
     CategoryScale,
@@ -34,8 +36,11 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [chartData, setChartData] = useState<any>(null);
     const [selected, setSelected] = useState<PainEntry | null>(null);
+    const [fullscreen, setFullscreen] = useState(false);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const chartRef = useRef<any>(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dialogChartRef = useRef<any>(null);
     const pointIdsRef = useRef<(string | null)[][]>([]); // ids dos pontos por dataset
 
     useEffect(() => {
@@ -86,10 +91,11 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
     }, [data]);
 
     useEffect(() => {
-        if (!chartRef.current?.canvas) return;
-        const canvas = chartRef.current.canvas || chartRef.current?.canvas;
+        const ref = chartRef;
+        if (!ref.current?.canvas) return;
+        const canvas = ref.current.canvas || ref.current?.canvas;
         const handleMouseMove = (event: MouseEvent) => {
-            const chart = chartRef.current?.chart || chartRef.current;
+            const chart = ref.current?.chart || ref.current;
             if (!chart) return;
             const points = chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, true);
             if (points.length) {
@@ -110,8 +116,36 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
         };
     }, [chartData, data]);
 
-    const handlePointClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-        const chart = chartRef.current?.chart || chartRef.current;
+    useEffect(() => {
+        if (!fullscreen) return;
+        const ref = dialogChartRef;
+        if (!ref.current?.canvas) return;
+        const canvas = ref.current.canvas || ref.current?.canvas;
+        const handleMouseMove = (event: MouseEvent) => {
+            const chart = ref.current?.chart || ref.current;
+            if (!chart) return;
+            const points = chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, true);
+            if (points.length) {
+                const { datasetIndex, index } = points[0];
+                const pointIds = pointIdsRef.current;
+                const id = pointIds[datasetIndex]?.[index];
+                const entry = data.find(e => e.id === id && e.comment);
+                if (entry) {
+                    canvas.style.cursor = 'pointer';
+                    return;
+                }
+            }
+            canvas.style.cursor = 'default';
+        };
+        canvas.addEventListener('mousemove', handleMouseMove);
+        return () => {
+            canvas.removeEventListener('mousemove', handleMouseMove);
+        };
+    }, [chartData, data, fullscreen]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handlePointClick = (event: React.MouseEvent<HTMLCanvasElement>, ref: React.MutableRefObject<any>) => {
+        const chart = ref.current?.chart || ref.current;
         if (!chart || !event || !event.nativeEvent) return;
         const points = chart.getElementsAtEventForMode(event.nativeEvent, 'nearest', { intersect: true }, true);
         if (points.length) {
@@ -170,10 +204,31 @@ export const PainChart: FC<PainChartProps> = ({ data }) => {
     return (
         <>
         <Paper elevation={3} sx={{ width: '100%', maxWidth: '100%', mx: 'auto', p: 4, mt: 4, background: 'rgba(40,40,40,0.95)', borderRadius: 3 }}>
-            <div style={{ minHeight: 500, width: '100%' }}>
-                <Line ref={chartRef} data={chartData} options={options} height={500} onClick={handlePointClick} />
+            <div style={{ position: 'relative', minHeight: 500, width: '100%' }}>
+                <IconButton
+                    aria-label="Ampliar gráfico"
+                    onClick={() => setFullscreen(true)}
+                    sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1, color: 'primary.main' }}
+                >
+                    <ZoomOutMapIcon />
+                </IconButton>
+                <Line ref={chartRef} data={chartData} options={options} height={500} onClick={e => handlePointClick(e, chartRef)} />
             </div>
         </Paper>
+        <Dialog fullScreen open={fullscreen} onClose={() => setFullscreen(false)}>
+            <DialogContent sx={{ bgcolor: 'background.default', p: 2 }}>
+                <IconButton
+                    aria-label="Fechar"
+                    onClick={() => setFullscreen(false)}
+                    sx={{ position: 'absolute', top: 8, right: 8, color: 'primary.contrastText' }}
+                >
+                    <CloseIcon />
+                </IconButton>
+                <div style={{ minHeight: 500 }}>
+                    <Line ref={dialogChartRef} data={chartData} options={options} height={500} onClick={e => handlePointClick(e, dialogChartRef)} />
+                </div>
+            </DialogContent>
+        </Dialog>
         <Dialog open={!!selected} onClose={() => setSelected(null)} maxWidth="sm" fullWidth>
             <DialogTitle>Comentário do Registro</DialogTitle>
             <DialogContent sx={{ minHeight: 80 }}>


### PR DESCRIPTION
## Summary
- allow opening the pain chart in fullscreen

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68654b4d0f24832da85e2989f3f71b1e